### PR TITLE
CloudFront invalidation on changed files only

### DIFF
--- a/lib/cloudfront/invalidator.rb
+++ b/lib/cloudfront/invalidator.rb
@@ -1,7 +1,7 @@
 module Jekyll
   module Cloudfront
     class Invalidator
-      def self.invalidate(config)
+      def self.invalidate(config, changed_files)
         aws_key = config['s3_id']
         aws_secret = config['s3_secret']
         s3_bucket_name = config['s3_bucket']
@@ -9,7 +9,8 @@ module Jekyll
         s3 = AWS::S3.new(
           :access_key_id => aws_key,
           :secret_access_key => aws_secret)
-        s3_object_keys = s3.buckets[s3_bucket_name].objects.map { |f| f.key }
+        s3_object_keys = changed_files
+        s3_object_keys << ""
         report = SimpleCloudfrontInvalidator::CloudfrontClient.new(
           aws_key, aws_secret, cloudfront_distribution_id).invalidate(
             s3_object_keys)

--- a/lib/jekyll-s3/cli.rb
+++ b/lib/jekyll-s3/cli.rb
@@ -10,9 +10,9 @@ module Jekyll
       def run(site_dir, in_headless_mode = false)
         CLI.check_configuration site_dir
         config = Jekyll::S3::ConfigLoader.load_configuration site_dir
-        new_files_count, changed_files_count, deleted_files_count = 
+        new_files_count, changed_files_count, deleted_files_count, changed_files = 
           Uploader.run(site_dir, config, in_headless_mode)
-        CLI.invalidate_cf_dist_if_configured config
+        CLI.invalidate_cf_dist_if_configured(config, changed_files)
         [new_files_count, changed_files_count, deleted_files_count]
       rescue JekyllS3Error => e
         puts e.message
@@ -21,10 +21,10 @@ module Jekyll
 
       private
 
-      def self.invalidate_cf_dist_if_configured(config)
+      def self.invalidate_cf_dist_if_configured(config, changed_files)
         cloudfront_configured = config['cloudfront_distribution_id'] &&
           (not config['cloudfront_distribution_id'].empty?)
-        Jekyll::Cloudfront::Invalidator.invalidate(config) if cloudfront_configured
+        Jekyll::Cloudfront::Invalidator.invalidate(config, changed_files) if cloudfront_configured
       end
 
       def self.check_configuration(site_dir)

--- a/lib/jekyll-s3/uploader.rb
+++ b/lib/jekyll-s3/uploader.rb
@@ -12,13 +12,13 @@ module Jekyll
 
         create_bucket_if_needed(s3, s3_bucket_name)
 
-        new_files_count, changed_files_count = upload_files(s3, s3_bucket_name, site_dir)
+        new_files_count, changed_files_count, changed_files = upload_files(s3, s3_bucket_name, site_dir)
 
         deleted_files_count = remove_superfluous_files(
           s3, s3_bucket_name, site_dir, in_headless_mode)
 
         puts "Done! Go visit: http://#{s3_bucket_name}.s3.amazonaws.com/index.html"
-        [new_files_count, changed_files_count, deleted_files_count]
+        [new_files_count, changed_files_count, deleted_files_count, changed_files]
       end
 
       private
@@ -48,7 +48,7 @@ module Jekyll
             upload_file(f, s3, s3_bucket_name, site_dir)
           end
         end
-        [new_files.length, changed_files.length]
+        [new_files.length, changed_files.length, changed_files]
       end
 
       def self.upload_file(file, s3, s3_bucket_name, site_dir)


### PR DESCRIPTION
Right now everything is invalidated on CloudFront and because invalidation on AWS's side is a bit slow I figured it would be better to just invalidate the changed files.

Thoughts?
