### PR TITLE
Reduced Redundancy Storage Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Deploy your jekyll site to S3.
 s3_id: YOUR_AWS_S3_ACCESS_KEY_ID
 s3_secret: YOUR_AWS_S3_SECRET_ACCESS_KEY
 s3_bucket: your.blog.bucket.com
+s3_reduced_redundancy: false
 cloudfront_distribution_id: YOUR_CLOUDFRONT_DIST_ID (OPTIONAL)
 </pre>
 
@@ -34,6 +35,14 @@ cloudfront_distribution_id: YOUR_CLOUDFRONT_DIST_ID (OPTIONAL)
 ## Deploy!
 
   * Run `jekyll-s3`. Done.
+
+## Reduced Redundancy
+
+You can reduce the cost of hosting your blog on S3 by using Reduced Redundancy Storage:
+
+  * In `_jekyll_s3.yml`, set `s3_reduced_redundancy: true`
+  * All objects uploaded after this change will use the Reduced Redundancy Storage.
+  * If you want to change all of the files in the bucket, you can change them through the AWS console, or update the timestamp on the files before running `jekyll-s3` again
 
 ## How to use Cloudfront to deliver your blog
 
@@ -59,6 +68,9 @@ Enable the headless mode by adding the `--headless` or `-h` argument after
 `jekyll-s3`.
 
 ## Changelog
+
+### 2.0.1
+* Added support for S3 reduced redundancy storage. Requires aws-sdk 1.8.0.
 
 ### 2.0.0
 

--- a/features/cli-output.feature
+++ b/features/cli-output.feature
@@ -21,6 +21,7 @@ Feature: Command-line interface feedback
       s3_id: YOUR_AWS_S3_ACCESS_KEY_ID
       s3_secret: YOUR_AWS_S3_SECRET_ACCESS_KEY
       s3_bucket: your.blog.bucket.com
+      s3_reduced_redundancy: false
       cloudfront_distribution_id: YOUR_CLOUDFRONT_DIST_ID (OPTIONAL)
       """
 
@@ -34,6 +35,7 @@ Feature: Command-line interface feedback
       s3_id: YOUR_AWS_S3_ACCESS_KEY_ID
       s3_secret: YOUR_AWS_S3_SECRET_ACCESS_KEY
       s3_bucket: your.blog.bucket.com
+      s3_reduced_redundancy: false
       """
 
   Scenario: Run jekyll-s3 with a malformed configuration file
@@ -50,6 +52,7 @@ Feature: Command-line interface feedback
       s3_id: YOUR_AWS_S3_ACCESS_KEY_ID
       s3_secret: YOUR_AWS_S3_SECRET_ACCESS_KEY
       s3_bucket: your.blog.bucket.com
+      s3_reduced_redundancy: false
       """
 
   Scenario: Run jekyll-s3 with a configuration file that does not contain a bucket
@@ -59,6 +62,7 @@ Feature: Command-line interface feedback
       s3_id: YOUR_AWS_S3_ACCESS_KEY_ID
       s3_secret: YOUR_AWS_S3_SECRET_ACCESS_KEY
       s3_bucket:
+      s3_reduced_redundancy: false
       """
     When I run `jekyll-s3`
     Then the output should contain:
@@ -67,6 +71,7 @@ Feature: Command-line interface feedback
       s3_id: YOUR_AWS_S3_ACCESS_KEY_ID
       s3_secret: YOUR_AWS_S3_SECRET_ACCESS_KEY
       s3_bucket: your.blog.bucket.com
+      s3_reduced_redundancy: false
       """
 
   Scenario: Run jekyll-s3
@@ -76,6 +81,7 @@ Feature: Command-line interface feedback
       s3_id: YOUR_AWS_S3_ACCESS_KEY_ID
       s3_secret: YOUR_AWS_S3_SECRET_ACCESS_KEY
       s3_bucket: your.blog.bucket.com
+      s3_reduced_redundancy: false
       """
     When I run `jekyll-s3`
     Then the output should contain:

--- a/jekyll-s3.gemspec
+++ b/jekyll-s3.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "jekyll-s3"
-  s.version     = "2.0.0"
+  s.version     = "2.0.1"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Philippe Creux", "Lauri Lehmijoki"]
   s.email       = ["pcreux@gmail.com", "lauri.lehmijoki@iki.fi"]

--- a/jekyll-s3.gemspec
+++ b/jekyll-s3.gemspec
@@ -15,7 +15,7 @@ distribution, making it easy to deliver your blog via the CDN.}
 
   s.default_executable = %q{jekyll-s3}
 
-  s.add_dependency 'aws-sdk', '~> 1.5.6'
+  s.add_dependency 'aws-sdk', '~> 1.8.0'
   s.add_dependency 'filey-diff', '~> 0.0.2'
   s.add_dependency 'simple-cloudfront-invalidator', '~> 1.0.0'
   s.add_dependency 'erubis', '~> 2.7.0'

--- a/lib/jekyll-s3/config_loader.rb
+++ b/lib/jekyll-s3/config_loader.rb
@@ -6,6 +6,7 @@ module Jekyll
 s3_id: YOUR_AWS_S3_ACCESS_KEY_ID
 s3_secret: YOUR_AWS_S3_SECRET_ACCESS_KEY
 s3_bucket: your.blog.bucket.com
+s3_reduced_redundancy: false
 cloudfront_distribution_id: YOUR_CLOUDFRONT_DIST_ID (OPTIONAL)
       EOF
 

--- a/lib/jekyll-s3/uploader.rb
+++ b/lib/jekyll-s3/uploader.rb
@@ -56,7 +56,6 @@ module Jekyll
       def self.upload_file(file, s3, s3_bucket_name, site_dir, s3_rrs)
         Retry.run_with_retry do
           mime_type = MIME::Types.type_for(file)
-          puts s3_rrs.to_s
           upload_succeeded = s3.buckets[s3_bucket_name].objects[file].write(
             File.read("#{site_dir}/#{file}"),
             :content_type => mime_type.first ,


### PR DESCRIPTION
This update adds support for Reduced Redundancy Storage. This can reduce the cost of hosting a site on S3 by 20%.

By default, RRS will not be used. To enable it, update _jekyll_s3.yml to include 's3_reduced_redundancy: true'. All files uploaded after this change will use RRS.
