### PR TITLE
Uploader: fix Dir[] regular expression to include dot files.

### DIFF
--- a/lib/jekyll-s3/uploader.rb
+++ b/lib/jekyll-s3/uploader.rb
@@ -93,7 +93,7 @@ module Jekyll
       end
 
       def self.load_all_local_files(site_dir)
-        Dir[site_dir + '/**/*'].
+        Dir[site_dir + '/**/{*,.*}'].
           delete_if { |f| File.directory?(f) }.
           map { |f| f.gsub(site_dir + '/', '') }
       end


### PR DESCRIPTION
Hi!

Thanks for jekyll-s3! :) I'm having issues the synchronizing of dotfiles with jekyll-s3 (respectively with filey-diff): there are just ignored on the local directory. I fixed the regular expression to include dotfiles.

Feel free to merge.
cu. stan.
