### PR TITLE
Automatically gzip files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ You can reduce the cost of hosting your blog on S3 by using Reduced Redundancy S
   * In `_jekyll_s3.yml`, set `s3_reduced_redundancy: true`
   * All objects uploaded after this change will use the Reduced Redundancy Storage.
   * If you want to change all of the files in the bucket, you can change them through the AWS console, or update the timestamp on the files before running `jekyll-s3` again
+  
+### Gzipping files
+
+By default, jekyll-s3 will gzip files with the extensions .html, .js, .css, .svg and .txt before uploading and then set S3 to deliver them with the Content-Encoding: gzip header.  You can change which extensions are gzipped by setting the gzip_extensions config key:
+
+    gzip_extensions:
+      - .html
+      - .css
+      - .js
+      - .tex
 
 ### How to use Cloudfront to deliver your blog
 

--- a/lib/jekyll-s3/uploader.rb
+++ b/lib/jekyll-s3/uploader.rb
@@ -64,7 +64,7 @@ module Jekyll
           
           s3_object = s3.buckets[config['s3_bucket']].objects[file]
           local_filename = "#{site_dir}/#{file}"
-          gzip = [".html", ".css", ".js", ".svg", ".txt"].include?(File.extname file)
+          gzip = (config['gzip_extensions'] || [".html", ".css", ".js", ".svg", ".txt"]).include?(File.extname file)
           
           upload_succeeded = if gzip
             Tempfile.open(File.basename(file)) do |tempfile|

--- a/lib/jekyll-s3/uploader.rb
+++ b/lib/jekyll-s3/uploader.rb
@@ -1,3 +1,6 @@
+require 'tempfile'
+require 'zlib'
+
 module Jekyll
   module S3
     class Uploader
@@ -54,15 +57,42 @@ module Jekyll
       def self.upload_file(file, s3, config, site_dir)
         Retry.run_with_retry do
           mime_type = MIME::Types.type_for(file)
-          upload_succeeded = s3.buckets[config['s3_bucket']].objects[file].write(
-            File.read("#{site_dir}/#{file}"),
+          metadata = {
             :content_type => mime_type.first,
             :reduced_redundancy => config['s3_reduced_redundancy']
-          )
-          if upload_succeeded
-            puts("Upload #{file}: Success!")
+          }
+          
+          s3_object = s3.buckets[config['s3_bucket']].objects[file]
+          local_filename = "#{site_dir}/#{file}"
+          gzip = [".html", ".css", ".js", ".svg", ".txt"].include?(File.extname file)
+          
+          upload_succeeded = if gzip
+            Tempfile.open(File.basename(file)) do |tempfile|
+              metadata[:content_encoding] = "gzip"
+              
+              gz = Zlib::GzipWriter.new(tempfile, Zlib::BEST_COMPRESSION, Zlib::DEFAULT_STRATEGY)
+              gz.mtime = File.mtime(local_filename)
+              gz.orig_name = File.basename(file)
+              File.open(local_filename) do |f|
+                IO.copy_stream(f, gz)
+              end                
+              gz.flush
+              
+              tempfile.flush
+              tempfile.rewind
+              s3_object.write(tempfile, metadata)
+              gz.close
+            end
           else
-            puts("Upload #{file}: FAILURE!")
+            File.open(local_filename) do |f|
+              s3_object.write(f, metadata)
+            end
+          end
+          
+          if upload_succeeded
+            puts("Upload #{file}#{gzip ? " (gzipped)" : ""}: Success!")
+          else
+            puts("Upload #{file}#{gzip ? " (gzipped)" : ""}: FAILURE!")
           end
         end
       end


### PR DESCRIPTION
This is a fairly simplistic implementation of the feature requested in issue #24.

Right now it's not smart enough to detect when a file doesn't match its uploaded version due to the uploaded version being gzipped, so it's re-uploading all gzippable files every time.  Obviously not ideal - the fix probably needs to also involve filey-diff.
