### PR TITLE
Adds max_age configuration option for better browser caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ s3_bucket: your.blog.bucket.com
 
 ## Additional features
 
+### Cache Control
+
+You can use the `max_age` configuration option to enable more effective browser
+caching of your static assets. There are two possible ways to use the option:
+you can specify a single age (in seconds) like so:
+
+```yaml
+max_age: 300
+```
+
+Or you can specify a hash of globs, and all files matching those globs will have
+the specified age:
+
+```yaml
+max_age:
+  "assets/*": 6000
+  "*": 300
+```
+
 ### Using non-standard AWS regions
 
 By default, `jekyll-s3` uses the US Standard Region. You can upload your Jekyll
@@ -42,7 +61,9 @@ site to other regions by adding the setting `s3_endpoint` into the
 For example, the following line in `_jekyll_s3.yml` will instruct `jekyll_s3` to
 push your site into the Tokyo region:
 
-    s3_endpoint: ap-northeast-1
+```yaml
+s3_endpoint: ap-northeast-1
+```
 
 The valid `s3_endpoint` values consist of the [S3 location constraint
 values](http://docs.amazonwebservices.com/general/latest/gr/rande.html#s3_region).

--- a/lib/jekyll-s3/upload.rb
+++ b/lib/jekyll-s3/upload.rb
@@ -52,8 +52,26 @@ module Jekyll
           :reduced_redundancy => config['s3_reduced_redundancy']
         }
 
-        opts[:content_encoding] = "gzip" if config['gzip']
+        opts[:content_encoding] = "gzip" if gzip?
+        opts[:cache_control] = "max-age=#{max_age}" if cache_control?
+        puts opts[:cache_control]
         opts
+      end
+
+      def cache_control?
+        !!config['max_age']
+      end
+
+      def max_age
+        if config['max_age'].is_a?(Hash)
+          config['max_age'].each_pair do |glob, age|
+            return age if File.fnmatch(glob, path)
+          end
+        else
+          return config['max_age']
+        end
+
+        return 0
       end
 
       def mime_type

--- a/lib/jekyll-s3/upload.rb
+++ b/lib/jekyll-s3/upload.rb
@@ -46,6 +46,10 @@ module Jekyll
         tempfile
       end
 
+      def details
+        "#{path}#{" [gzipped]" if gzip?}#{" [max-age=#{max_age}]" if cache_control?}"
+      end
+
       def upload_options
         opts = {
           :content_type => mime_type,
@@ -54,7 +58,7 @@ module Jekyll
 
         opts[:content_encoding] = "gzip" if gzip?
         opts[:cache_control] = "max-age=#{max_age}" if cache_control?
-        puts opts[:cache_control]
+        
         opts
       end
 

--- a/lib/jekyll-s3/uploader.rb
+++ b/lib/jekyll-s3/uploader.rb
@@ -52,15 +52,15 @@ module Jekyll
       end
 
       def self.upload_file(file, s3, config, site_dir)
-        # Retry.run_with_retry do
+        Retry.run_with_retry do
           upload = Upload.new(file, s3, config, site_dir)
 
           if upload.perform!
-            puts("Upload #{file}: Success!")
+            puts "Upload #{upload.details}: Success!"
           else
-            puts("Upload #{file}: FAILURE!")
+            puts "Upload #{upload.details}: FAILURE!"
           end
-        # end
+        end
       end
 
       def self.remove_superfluous_files(s3, s3_bucket_name, site_dir, in_headless_mode)


### PR DESCRIPTION
This adds a `max_age` configuration option that can be set to enable cache control headers on the uploaded files. It works either as a universal constant or with file globs.

Note that this code is dependent on the refactorings I made for #26...if you want cache control merged but not gzip let me know and i'll pull out the gzip features for the time being.
