### PR TITLE
Moved default location constraint logic from config loader to endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Fork!
+
+In this fork, I'd like to implement distrubuted builds. This would require implementation of http://github.com/adelevie/big-processing and some simple edits to the `Uploader` class.
+
 # jekyll-s3
 
 [![Build Status](https://secure.travis-ci.org/laurilehmijoki/jekyll-s3.png)] (http://travis-ci.org/laurilehmijoki/jekyll-s3)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# Fork!
-
-In this fork, I'd like to implement distrubuted builds. This would require implementation of http://github.com/adelevie/big-processing and some simple edits to the `Uploader` class.
-
 # jekyll-s3
 
 [![Build Status](https://secure.travis-ci.org/laurilehmijoki/jekyll-s3.png)] (http://travis-ci.org/laurilehmijoki/jekyll-s3)

--- a/features/jekyll-s3-as-library.feature
+++ b/features/jekyll-s3-as-library.feature
@@ -21,9 +21,3 @@ Feature: Using Jekyll-s3 as a library
     When my Jekyll site is in "features/support/test_site_dirs/cdn-powered.with-one-change.blog.fi"
     Then jekyll-s3 will push my blog to S3 and invalidate the Cloudfront distribution
     And report that it invalidated 2 Cloudfront item
-
-  @s3-basic-site-build
-  Scenario: Developer wants to programatically invoke the same functionality as the CLI in order to build his/her site
-    When my Jekyll site is in "features/support/test_site_dirs/basic-site-build-non-cli"
-    Then calling something like `Jekyll::S3::Uploader(...)` will upload the contents of the `_site` folder to S3
-    And report that the upload was successful

--- a/features/jekyll-s3-as-library.feature
+++ b/features/jekyll-s3-as-library.feature
@@ -21,3 +21,9 @@ Feature: Using Jekyll-s3 as a library
     When my Jekyll site is in "features/support/test_site_dirs/cdn-powered.with-one-change.blog.fi"
     Then jekyll-s3 will push my blog to S3 and invalidate the Cloudfront distribution
     And report that it invalidated 2 Cloudfront item
+
+  @s3-basic-site-build
+  Scenario: Developer wants to programatically invoke the same functionality as the CLI in order to build his/her site
+    When my Jekyll site is in "features/support/test_site_dirs/basic-site-build-non-cli"
+    Then calling something like `Jekyll::S3::Uploader(...)` will upload the contents of the `_site` folder to S3
+    And report that the upload was successful

--- a/lib/jekyll-s3/config_loader.rb
+++ b/lib/jekyll-s3/config_loader.rb
@@ -24,7 +24,6 @@ s3_bucket: your.blog.bucket.com
       # Raise MalformedConfigurationFileError if the configuration file does not contain the keys we expect
       def self.load_configuration(site_dir)
         config = load_yaml_file_and_validate site_dir
-        config['s3_endpoint'] = config['s3_endpoint'] || 'us-east-1'
         return config
       end
 

--- a/lib/jekyll-s3/endpoint.rb
+++ b/lib/jekyll-s3/endpoint.rb
@@ -25,6 +25,6 @@ module Jekyll
           'sa-east-1'      => { :region => 'South America (Sao Paulo)',     :website_hostname => 's3-website-sa-east-1.amazonaws.com',      :endpoint => 's3-sa-east-1.amazonaws.com' }
         }
       end
-  end
+    end
   end
 end

--- a/lib/jekyll-s3/endpoint.rb
+++ b/lib/jekyll-s3/endpoint.rb
@@ -1,9 +1,11 @@
 module Jekyll
   module S3
     class Endpoint
+      DEFAULT_LOCATION_CONSTRAINT = 'us-east-1'
       attr_reader :region, :location_constraint, :hostname, :website_hostname
 
-      def initialize(location_constraint)
+      def initialize(location_constraint=nil)
+        location_constraint = DEFAULT_LOCATION_CONSTRAINT if location_constraint.nil?
         raise "Invalid S3 location constraint #{location_constraint}" unless
           location_constraints.has_key?location_constraint
         @region = location_constraints.fetch(location_constraint)[:region]

--- a/spec/lib/config_loader_spec.rb
+++ b/spec/lib/config_loader_spec.rb
@@ -8,11 +8,6 @@ describe Jekyll::S3::ConfigLoader do
     config['s3_bucket'].should eq('galaxy')
   end
 
-  it 'uses the "us-east-1" as the default endpoint' do
-    config = Jekyll::S3::ConfigLoader.load_configuration('spec/sample_files/hyde_site/_site')
-    config['s3_endpoint'].should eq('us-east-1')
-  end
-
   it 'reads the S3 endpoint setting from _jekyll_s3.yml' do
     config = Jekyll::S3::ConfigLoader.load_configuration('spec/sample_files/tokyo_site/_site')
     config['s3_endpoint'].should eq('ap-northeast-1')

--- a/spec/lib/endpoint_spec.rb
+++ b/spec/lib/endpoint_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'pp'
+
+describe Jekyll::S3::Endpoint do
+  
+  it 'uses the "us-east-1" as the default location' do
+    endpoint = Jekyll::S3::Endpoint.new
+    endpoint.location_constraint.should eq(Jekyll::S3::Endpoint::DEFAULT_LOCATION_CONSTRAINT)
+  end
+
+end


### PR DESCRIPTION
This will allow `Jekyll::S3::Uploader` to be run programmatically while providing a sane default that you'd get from a `yml` config file.

I cannot get the full test suite to run properly, but running the affected specs, tests pass:

``` sh
adelevie@Alans-MacBook-Air:jekyll-s3 → master rspec spec/lib/endpoint_spec.rb 
.

Finished in 0.00105 seconds
1 example, 0 failures
adelevie@Alans-MacBook-Air:jekyll-s3 → master rspec spec/lib/config_loader_spec.rb 
..

Finished in 0.00567 seconds
2 examples, 0 failures
```

Notice that I completely removed a test from the config loader spec and moved its equivalent to a new file, `endpoint_spec.rb`.
