### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ is_headless = true
 Jekyll::S3::CLI.new.run('/path/to/your/jekyll-site/_site/', is_headless)
 ````
 
+You can also use a basic `Hash` instead of a `_jekyll_s3.yml` file:
+
+```ruby
+config = {
+  "s3_id"     => YOUR_AWS_S3_ACCESS_KEY_ID,
+  "s3_secret" => YOUR_AWS_S3_SECRET_ACCESS_KEY,
+  "s3_bucket" => your.blog.bucket.com
+}
+in_headless = true
+Jekyll::S3::Uploader.run('/path/to/your/jekyll-site/_site/', config, in_headless)
+```
+
 The code above will assume that you have the `_jekyll_s3.yml` in the directory
 `/path/to/your/jekyll-site`.
 


### PR DESCRIPTION
Shows example for using a Hash instead of a .yml config file. Addresses part of https://github.com/laurilehmijoki/jekyll-s3/issues/33
