### PR TITLE
Refactor endpoint_spec to keep tests concerned with only one thing

### DIFF
--- a/spec/lib/endpoint_spec.rb
+++ b/spec/lib/endpoint_spec.rb
@@ -3,9 +3,13 @@ require 'pp'
 
 describe Jekyll::S3::Endpoint do
 
-  it 'uses the "us-east-1" as the default location' do
+  it 'uses the DEFAULT_LOCATION_CONSTRAINT constant to set the default location constraint' do
     endpoint = Jekyll::S3::Endpoint.new
     endpoint.location_constraint.should eq(Jekyll::S3::Endpoint::DEFAULT_LOCATION_CONSTRAINT)
+  end
+
+  it 'uses the "us-east-1" as the default location' do
+    Jekyll::S3::Endpoint::DEFAULT_LOCATION_CONSTRAINT.should eq('us-east-1')
   end
 
   it 'takes a valid location constraint as a constructor parameter' do
@@ -19,3 +23,5 @@ describe Jekyll::S3::Endpoint do
     }.to raise_error
   end
 end
+
+


### PR DESCRIPTION
If you ever did want to change the default location constraint, it should not effect the defaulting logic itself. This change turns one test into two smaller ones.
