### PR TITLE
Specify a character set

### DIFF
--- a/lib/jekyll-s3/upload.rb
+++ b/lib/jekyll-s3/upload.rb
@@ -61,6 +61,7 @@ module Jekyll
           :reduced_redundancy => config['s3_reduced_redundancy']
         }
 
+        opts[:content_type] = "text/html; charset=utf-8" if mime_type == 'text/html'
         opts[:content_encoding] = "gzip" if gzip?
         opts[:cache_control] = "max-age=#{max_age}" if cache_control?
 


### PR DESCRIPTION
`text/html` Files should have the character set specified in the type header. `text/html; charset=utf-8`

Perhaps this would fit better in [mojombo/jekyll](https://github.com/mojombo/jekyll), I'm not sure.
