### PR TITLE
Allow s3_id and s3_secret to be omitted

### DIFF
--- a/lib/jekyll-s3/config_loader.rb
+++ b/lib/jekyll-s3/config_loader.rb
@@ -41,7 +41,7 @@ s3_bucket: your.blog.bucket.com
         end
         raise MalformedConfigurationFileError unless config
         raise MalformedConfigurationFileError if
-          ['s3_id', 's3_secret', 's3_bucket'].any? { |key|
+          ['s3_bucket'].any? { |key|
             mandatory_config_value = config[key]
             mandatory_config_value.nil? || mandatory_config_value == ''
           }

--- a/lib/jekyll-s3/uploader.rb
+++ b/lib/jekyll-s3/uploader.rb
@@ -4,9 +4,13 @@ module Jekyll
       def self.run(site_dir, config, in_headless_mode = false)
         puts "Deploying _site/* to #{config['s3_bucket']}"
 
-        s3 = AWS::S3.new(:access_key_id => config['s3_id'],
-                         :secret_access_key => config['s3_secret'],
-                         :s3_endpoint => Endpoint.new(config['s3_endpoint']).hostname )
+        s3_config = { :s3_endpoint => Endpoint.new(config['s3_endpoint']).hostname }
+        s3_id, s3_secret = config['s3_id'], config['s3_secret']
+        unless s3_id.nil? || s3_id == '' || s3_secret.nil? || s3_secret == ''
+          s3_config.merge! :access_key_id => s3_id, :secret_access_key => s3_secret
+        end
+
+        s3 = AWS::S3.new(s3_config)
 
         new_files_count, changed_files_count, changed_files = upload_files(
           s3, config, site_dir


### PR DESCRIPTION
This enables deploying jekyll-s3 on EC2 instances with IAM roles.
The AWS SDK will automatically fetch temporary credentials.
