### PR TITLE
Simple Redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,30 @@ Enable the headless mode by adding the `--headless` or `-h` argument after
 
 ### Configuring redirects on your Jekyll S3 website
 
-You can set HTTP redirects on your Jekyll S3 website by adding the following
+You can set HTTP redirects on your Jekyll S3 website in two ways. If you only
+need simple "301 Moved Premanently" redirects for certain keys, use the
+Simple Redirects method. Otherwise, use the Routing Rules method.
+  
+#### Simple Redirects
+
+For simple redirects Jekyll S3 uses Amazon S3's
+[`x-amz-website-redirect-location`](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html)
+metadata. It will create zero-byte objects for each path you want
+redirected with the appropriate `x-amz-website-redirect-location` value.
+
+For setting up simple redirect rules, simply list each path and target
+as key-value pairs under the `redirects` configuration option:
+
+```yaml
+redirects:
+  index.php: /
+  about.php: about.html
+  promo.mp4: http://www.youtube.com/watch?v=dQw4w9WgXcQ
+```
+
+#### Routing Rules
+  
+You can configure more complex redirect rules by adding the following
 configuration into the `_jekyll_s3.yml` file:
 
 ```yaml

--- a/lib/jekyll-s3/cli.rb
+++ b/lib/jekyll-s3/cli.rb
@@ -10,15 +10,16 @@ module Jekyll
       def run(site_dir, in_headless_mode = false)
         CLI.check_configuration site_dir
         config = Jekyll::S3::ConfigLoader.load_configuration site_dir
-        new_files_count, changed_files_count, deleted_files_count, changed_files =
+        new_files_count, changed_files_count, deleted_files_count, changed_files, changed_redirects =
           Uploader.run(site_dir, config, in_headless_mode)
         invalidated_items_count =
-          CLI.invalidate_cf_dist_if_configured(config, changed_files)
+          CLI.invalidate_cf_dist_if_configured(config, changed_files + changed_redirects)
         {
           :new_files_count => new_files_count,
           :changed_files_count => changed_files_count,
           :deleted_files_count => deleted_files_count,
-          :invalidated_items_count => invalidated_items_count
+          :invalidated_items_count => invalidated_items_count,
+          :changed_redirects_count => changed_redirects.size
         }
       rescue JekyllS3Error => e
         puts e.message

--- a/lib/jekyll-s3/uploader.rb
+++ b/lib/jekyll-s3/uploader.rb
@@ -17,8 +17,11 @@ module Jekyll
         )
 
         redirects = config['redirects'] || {}
+        changed_redirects = []
         redirects.each do |path, target|
-          setup_redirect(path, target, s3, config)
+          if setup_redirect(path, target, s3, config)
+            changed_redirects << path
+          end
         end
 
         deleted_files_count = remove_superfluous_files(s3, { :s3_bucket => config['s3_bucket'],
@@ -29,7 +32,7 @@ module Jekyll
 
         print_done_report config
 
-        [new_files_count, changed_files_count, deleted_files_count, changed_files]
+        [new_files_count, changed_files_count, deleted_files_count, changed_files, changed_redirects]
       end
 
       private
@@ -90,6 +93,7 @@ module Jekyll
           else
             puts "Redirect #{path} to #{target}: FAILURE!"
           end
+          true
         end
       end
 


### PR DESCRIPTION
Setup simple "301 Moved Permanently" redirects through the config file:

``` yaml
redirects:
  index.php: /
  about.php: about.html
  promo.mp4: http://www.youtube.com/watch?v=dQw4w9WgXcQ
```

See #48 for a discussion on the feature. I opted for the third approach because it was the easiest to implement. Looking at the AWS Ruby SDK I couldn't find an easy way to generalize managing metadata.
